### PR TITLE
[ISS-5465] add a flag to let CA delegate node deletion to the external node provisioner

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
@@ -116,7 +116,7 @@ func (asg *Asg) Belongs(node *apiv1.Node) (bool, error) {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
+func (asg *Asg) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	size, err := asg.manager.GetAsgSize(asg)
 	if err != nil {
 		klog.Errorf("failed to get ASG size because of %s", err.Error())

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -290,7 +290,7 @@ func (ng *AwsNodeGroup) Belongs(node *apiv1.Node) (bool, error) {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (ng *AwsNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *AwsNodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	size := ng.asg.curSize
 	if int(size) <= ng.MinSize() {
 		return fmt.Errorf("min size reached, nodes will not be deleted")

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -430,7 +430,7 @@ func TestDeleteNodes(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id",
 		},
 	}
-	err = asgs[0].DeleteNodes([]*apiv1.Node{node})
+	err = asgs[0].DeleteNodes([]*apiv1.Node{node}, false)
 	assert.NoError(t, err)
 	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 1)
 	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
@@ -483,7 +483,7 @@ func TestDeleteNodesWithPlaceholder(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/i-placeholder-test-asg-1",
 		},
 	}
-	err = asgs[0].DeleteNodes([]*apiv1.Node{node})
+	err = asgs[0].DeleteNodes([]*apiv1.Node{node}, false)
 	assert.NoError(t, err)
 	a.AssertNumberOfCalls(t, "SetDesiredCapacity", 1)
 	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroupsPages", 1)
@@ -527,7 +527,7 @@ func TestDeleteNodesAfterMultipleRefreshes(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id",
 		},
 	}
-	err := asgs[0].DeleteNodes([]*apiv1.Node{node})
+	err := asgs[0].DeleteNodes([]*apiv1.Node{node}, false)
 	assert.NoError(t, err)
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -423,7 +423,7 @@ func (as *AgentPool) DeleteInstances(instances []*azureRef) error {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
+func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	klog.V(6).Infof("Delete nodes requested: %v\n", nodes)
 	indexes, _, err := as.GetVMIndexes()
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
@@ -440,7 +440,7 @@ func TestAgentPoolDeleteNodes(t *testing.T) {
 			Spec:       apiv1.NodeSpec{ProviderID: testInvalidProviderID},
 			ObjectMeta: v1.ObjectMeta{Name: "node"},
 		},
-	})
+	}, false)
 	expectedErr := fmt.Errorf("node doesn't belong to a known agent pool")
 	assert.Equal(t, expectedErr, err)
 
@@ -451,7 +451,7 @@ func TestAgentPoolDeleteNodes(t *testing.T) {
 			Spec:       apiv1.NodeSpec{ProviderID: testValidProviderID0},
 			ObjectMeta: v1.ObjectMeta{Name: "node"},
 		},
-	})
+	}, false)
 	expectedErr = fmt.Errorf("node belongs to a different asg than as")
 	assert.Equal(t, expectedErr, err)
 
@@ -468,12 +468,12 @@ func TestAgentPoolDeleteNodes(t *testing.T) {
 			Spec:       apiv1.NodeSpec{ProviderID: testValidProviderID0},
 			ObjectMeta: v1.ObjectMeta{Name: "node"},
 		},
-	})
+	}, false)
 	expectedErrStr := "The specified account is disabled."
 	assert.True(t, strings.Contains(err.Error(), expectedErrStr))
 
 	as.minSize = 3
-	err = as.DeleteNodes([]*apiv1.Node{})
+	err = as.DeleteNodes([]*apiv1.Node{}, false)
 	expectedErr = fmt.Errorf("min size reached, nodes will not be deleted")
 	assert.Equal(t, expectedErr, err)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool.go
@@ -295,7 +295,7 @@ func (agentPool *AKSAgentPool) deleteNodesInternal(providerIDs []string) (delete
 
 // DeleteNodes extracts the providerIDs from the node spec and calls into the internal
 // delete method.
-func (agentPool *AKSAgentPool) DeleteNodes(nodes []*apiv1.Node) error {
+func (agentPool *AKSAgentPool) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	agentPool.mutex.Lock()
 	defer agentPool.mutex.Unlock()
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_kubernetes_service_pool_test.go
@@ -337,7 +337,7 @@ func TestDeleteNodesAKS(t *testing.T) {
 			},
 		},
 	}
-	err := aksPool.DeleteNodes(nodes)
+	err := aksPool.DeleteNodes(nodes, false)
 	assert.Equal(t, 4, aksPool.curSize)
 	assert.NoError(t, err)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -427,7 +427,7 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef, hasUnregistered
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
+func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	klog.V(8).Infof("Delete nodes requested: %q\n", nodes)
 	size, err := scaleSet.GetScaleSetSize()
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -309,7 +309,7 @@ func TestDeleteNodes(t *testing.T) {
 			},
 		},
 	}
-	err = scaleSet.DeleteNodes(nodesToDelete)
+	err = scaleSet.DeleteNodes(nodesToDelete, false)
 	assert.NoError(t, err)
 	vmssCapacity = 1
 	expectedScaleSets = []compute.VirtualMachineScaleSet{
@@ -404,7 +404,7 @@ func TestDeleteNodeUnregistered(t *testing.T) {
 			},
 		},
 	}
-	err = scaleSet.DeleteNodes(nodesToDelete)
+	err = scaleSet.DeleteNodes(nodesToDelete, false)
 	assert.NoError(t, err)
 
 	// Ensure the the cached size has NOT been proactively decremented
@@ -473,7 +473,7 @@ func TestDeleteNoConflictRequest(t *testing.T) {
 	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
 	assert.True(t, ok)
 
-	err = scaleSet.DeleteNodes([]*apiv1.Node{node})
+	err = scaleSet.DeleteNodes([]*apiv1.Node{node}, false)
 }
 
 func TestId(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -281,7 +281,7 @@ func (asg *Asg) IncreaseSize(delta int) error {
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
+func (asg *Asg) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	size, err := asg.baiducloudManager.GetAsgSize(asg)
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
@@ -104,7 +104,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	ctx := context.Background()
 	for _, node := range nodes {
 		nodeID, ok := node.Labels[nodeIDLabel]

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group_test.go
@@ -288,7 +288,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 		client.On("DeleteClusterWorkerPoolNode", ctx, ng.clusterID, ng.id, "2", nil).Return(nil).Once()
 		client.On("DeleteClusterWorkerPoolNode", ctx, ng.clusterID, ng.id, "3", nil).Return(nil).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(nodes, false)
 		assert.NoError(t, err)
 	})
 
@@ -314,7 +314,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 		client.On("DeleteClusterWorkerPoolNode", ctx, ng.clusterID, ng.id, "1", nil).Return(nil).Once()
 		client.On("DeleteClusterWorkerPoolNode", ctx, ng.clusterID, ng.id, "2", nil).Return(errors.New("random error")).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(nodes, false)
 		assert.Error(t, err)
 	})
 }

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group.go
@@ -127,7 +127,7 @@ func (ng *brightboxNodeGroup) IncreaseSize(delta int) error {
 // either on failure or if the given node doesn't belong to this
 // node group. This function should wait until node group size is
 // updated. Implementation required.
-func (ng *brightboxNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *brightboxNodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	klog.V(4).Info("DeleteNodes")
 	klog.V(4).Infof("Nodes: %+v", nodes)
 	for _, node := range nodes {

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group_test.go
@@ -225,11 +225,11 @@ func TestDeleteNodes(t *testing.T) {
 		On("Server", fakeServer).
 		Return(fakeServertesty(), nil)
 	t.Run("Empty Nodes", func(t *testing.T) {
-		err := nodeGroup.DeleteNodes(nil)
+		err := nodeGroup.DeleteNodes(nil, false)
 		assert.NoError(t, err)
 	})
 	t.Run("Foreign Node", func(t *testing.T) {
-		err := nodeGroup.DeleteNodes([]*v1.Node{makeNode(fakeServer)})
+		err := nodeGroup.DeleteNodes([]*v1.Node{makeNode(fakeServer)}, false)
 		assert.Error(t, err)
 	})
 	t.Run("Delete Node", func(t *testing.T) {
@@ -240,7 +240,7 @@ func TestDeleteNodes(t *testing.T) {
 			Once().
 			On("DestroyServer", "srv-rp897").
 			Return(nil).Once()
-		err := nodeGroup.DeleteNodes([]*v1.Node{makeNode("srv-rp897")})
+		err := nodeGroup.DeleteNodes([]*v1.Node{makeNode("srv-rp897")}, false)
 		assert.NoError(t, err)
 	})
 	t.Run("Delete All Nodes", func(t *testing.T) {
@@ -255,7 +255,7 @@ func TestDeleteNodes(t *testing.T) {
 		err := nodeGroup.DeleteNodes([]*v1.Node{
 			makeNode("srv-rp897"),
 			makeNode("srv-lv426"),
-		})
+		}, false)
 		assert.Error(t, err)
 	})
 

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group.go
@@ -114,7 +114,7 @@ func (ng *cherryNodeGroup) IncreaseSize(delta int) error {
 }
 
 // DeleteNodes deletes a set of nodes chosen by the autoscaler.
-func (ng *cherryNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *cherryNodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	// Batch simultaneous deletes on individual nodes
 	if err := ng.addNodesToDelete(nodes); err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group_test.go
@@ -244,10 +244,10 @@ func TestIncreaseDecreaseSize(t *testing.T) {
 		}
 	}
 
-	err = ngPool2.DeleteNodes(nodesPool2)
+	err = ngPool2.DeleteNodes(nodesPool2, false)
 	assert.NoError(t, err)
 
-	err = ngPool3.DeleteNodes(nodesPool3)
+	err = ngPool3.DeleteNodes(nodesPool3, false)
 	assert.NoError(t, err)
 
 	// Wait a few seconds if talking to the actual Cherry API

--- a/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
@@ -104,7 +104,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	for _, node := range nodes {
 		instanceID := toNodeID(node.Spec.ProviderID)
 		klog.V(4).Info("deleteing node: %q", instanceID)

--- a/cluster-autoscaler/cloudprovider/civo/civo_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_node_group_test.go
@@ -250,7 +250,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 			nil,
 		).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(nodes, false)
 		assert.NoError(t, err)
 	})
 
@@ -286,7 +286,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 			errors.New("random error"),
 		).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(nodes, false)
 		assert.Error(t, err)
 	})
 }

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -179,7 +179,7 @@ type NodeGroup interface {
 	// DeleteNodes deletes nodes from this node group. Error is returned either on
 	// failure or if the given node doesn't belong to this node group. This function
 	// should wait until node group size is updated. Implementation required.
-	DeleteNodes([]*apiv1.Node) error
+	DeleteNodes([]*apiv1.Node, bool) error
 
 	// DecreaseTargetSize decreases the target size of the node group. This function
 	// doesn't permit to delete any existing node and can be used only to reduce the

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
@@ -94,7 +94,7 @@ func (asg *asg) Belongs(node *apiv1.Node) (bool, error) {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (asg *asg) DeleteNodes(nodes []*apiv1.Node) error {
+func (asg *asg) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	if asg.cluster.WorkerCount-len(nodes) < asg.MinSize() {
 		return fmt.Errorf("Goes below minsize. Can not delete %v nodes", len(nodes))
 	}

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group_test.go
@@ -170,7 +170,7 @@ func testDeleteNodesError(t *testing.T) {
 
 	// Can't go below minSize
 	asg := createASG()
-	err := asg.DeleteNodes(nodes)
+	err := asg.DeleteNodes(nodes, false)
 	clusterDetails := createClusterDetails()
 	assert.Equal(t, clusterDetails, asg.cluster)
 	assert.NotEqual(t, nil, err)
@@ -196,7 +196,7 @@ func testDeleteNodesSuccess(t *testing.T) {
 				},
 			},
 		},
-	})
+	}, false)
 	scaleDownClusterDetails := createScaleDownClusterDetails()
 	assert.Equal(t, scaleDownClusterDetails, asg.cluster)
 	assert.Equal(t, nil, err)

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -671,7 +671,7 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 			}
 		}
 
-		if err := ng.DeleteNodes(testConfig.nodes[5:]); err != nil {
+		if err := ng.DeleteNodes(testConfig.nodes[5:], false); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 
@@ -768,7 +768,7 @@ func TestNodeGroupMachineSetDeleteNodesWithMismatchedNodes(t *testing.T) {
 		}
 
 		// Deleting nodes that are not in ng0 should fail.
-		err0 := ng0.DeleteNodes(testConfig1.nodes)
+		err0 := ng0.DeleteNodes(testConfig1.nodes, false)
 		if err0 == nil {
 			t.Error("expected an error")
 		}
@@ -780,7 +780,7 @@ func TestNodeGroupMachineSetDeleteNodesWithMismatchedNodes(t *testing.T) {
 		}
 
 		// Deleting nodes that are not in ng1 should fail.
-		err1 := ng1.DeleteNodes(testConfig0.nodes)
+		err1 := ng1.DeleteNodes(testConfig0.nodes, false)
 		if err1 == nil {
 			t.Error("expected an error")
 		}
@@ -791,13 +791,13 @@ func TestNodeGroupMachineSetDeleteNodesWithMismatchedNodes(t *testing.T) {
 
 		// Deleting from correct node group should fail because
 		// replicas would become <= 0.
-		if err := ng0.DeleteNodes(testConfig0.nodes); err == nil {
+		if err := ng0.DeleteNodes(testConfig0.nodes, false); err == nil {
 			t.Error("expected error")
 		}
 
 		// Deleting from correct node group should fail because
 		// replicas would become <= 0.
-		if err := ng1.DeleteNodes(testConfig1.nodes); err == nil {
+		if err := ng1.DeleteNodes(testConfig1.nodes, false); err == nil {
 			t.Error("expected error")
 		}
 	}
@@ -906,7 +906,7 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 		}
 
 		// Delete all nodes over the expectedSize
-		if err := ng.DeleteNodes(nodesToBeDeleted); err != nil {
+		if err := ng.DeleteNodes(nodesToBeDeleted, false); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -966,7 +966,7 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 		// Attempt to delete the nodes again which verifies
 		// that nodegroup.DeleteNodes() skips over nodes that
 		// have a non-nil DeletionTimestamp value.
-		if err := ng.DeleteNodes(nodesToBeDeleted); err != nil {
+		if err := ng.DeleteNodes(nodesToBeDeleted, false); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -1097,7 +1097,7 @@ func TestNodeGroupDeleteNodesSequential(t *testing.T) {
 		}
 
 		for node, nodeGroup := range nodeToNodeGroup {
-			if err := nodeGroup.DeleteNodes([]*corev1.Node{node}); err != nil {
+			if err := nodeGroup.DeleteNodes([]*corev1.Node{node}, false); err != nil {
 				t.Fatalf("unexpected error deleting node: %v", err)
 			}
 		}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -203,6 +203,11 @@ func (r unstructuredScalableResource) Taints() []apiv1.Taint {
 	return nil
 }
 
+// If true, Cluster Autoscaler will only mark nodes for deletion, and rely on the node provisioner to delete them
+func (r unstructuredScalableResource) ExternalNodeDeletionEnabled() bool {
+	return externalNodeDeletionEnabled(r.unstructured.GetAnnotations())
+}
+
 // A node group can scale from zero if it can inform about the CPU and memory
 // capacity of the nodes within the group.
 func (r unstructuredScalableResource) CanScaleFromZero() bool {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -36,6 +36,8 @@ const (
 	maxPodsKey      = "capacity.cluster-autoscaler.kubernetes.io/maxPods"
 	taintsKey       = "capacity.cluster-autoscaler.kubernetes.io/taints"
 	labelsKey       = "capacity.cluster-autoscaler.kubernetes.io/labels"
+
+	externalNodeDeletionKey = "cluster-autoscaler.kubernetes.io/external-node-deletion"
 )
 
 var (
@@ -227,6 +229,15 @@ func parseGPUType(annotations map[string]string) string {
 
 func parseMaxPodsCapacity(annotations map[string]string) (resource.Quantity, error) {
 	return parseIntKey(annotations, maxPodsKey)
+}
+
+// If true, Cluster Autoscaler will only mark nodes for deletion, and rely on the node provisioner to delete them
+func externalNodeDeletionEnabled(annotations map[string]string) bool {
+	val, ok := annotations[externalNodeDeletionKey]
+	if ok && val == "true" {
+		return true
+	}
+	return false
 }
 
 func clusterNameFromResource(r *unstructured.Unstructured) string {

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
@@ -110,7 +110,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	ctx := context.Background()
 	for _, node := range nodes {
 		nodeID, ok := node.Labels[nodeIDLabel]

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
@@ -275,7 +275,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 		client.On("DeleteNode", ctx, ng.clusterID, ng.id, "2", nil).Return(&godo.Response{}, nil).Once()
 		client.On("DeleteNode", ctx, ng.clusterID, ng.id, "3", nil).Return(&godo.Response{}, nil).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(nodes, false)
 		assert.NoError(t, err)
 	})
 
@@ -297,7 +297,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 		client.On("DeleteNode", ctx, ng.clusterID, ng.id, "2", nil).
 			Return(&godo.Response{}, errors.New("random error")).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(nodes, false)
 		assert.Error(t, err)
 	})
 }

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
@@ -96,7 +96,7 @@ func (n *instancePoolNodeGroup) IncreaseSize(delta int) error {
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (n *instancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *instancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	n.Lock()
 	defer n.Unlock()
 

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool_test.go
@@ -149,7 +149,7 @@ func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_DeleteNodes() {
 		m: ts.p.manager,
 	}
 
-	ts.Require().NoError(nodeGroup.DeleteNodes([]*apiv1.Node{node}))
+	ts.Require().NoError(nodeGroup.DeleteNodes([]*apiv1.Node{node}, false))
 }
 
 func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_Id() {

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
@@ -95,7 +95,7 @@ func (n *sksNodepoolNodeGroup) IncreaseSize(delta int) error {
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (n *sksNodepoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *sksNodepoolNodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	n.Lock()
 	defer n.Unlock()
 

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool_test.go
@@ -179,7 +179,7 @@ func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_DeleteNodes() {
 		m: ts.p.manager,
 	}
 
-	ts.Require().NoError(nodeGroup.DeleteNodes([]*apiv1.Node{node}))
+	ts.Require().NoError(nodeGroup.DeleteNodes([]*apiv1.Node{node}, false))
 }
 
 func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_Id() {

--- a/cluster-autoscaler/cloudprovider/externalgrpc/examples/external-grpc-cloud-provider-service/wrapper/wrapper.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/examples/external-grpc-cloud-provider-service/wrapper/wrapper.go
@@ -250,7 +250,7 @@ func (w *Wrapper) NodeGroupDeleteNodes(_ context.Context, req *protos.NodeGroupD
 	for _, n := range req.GetNodes() {
 		nodes = append(nodes, apiv1Node(n))
 	}
-	err := ng.DeleteNodes(nodes)
+	err := ng.DeleteNodes(nodes, false)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
@@ -94,7 +94,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	pbNodes := make([]*protos.ExternalGrpcNode, 0)
 	for _, n := range nodes {
 		pbNodes = append(pbNodes, externalGrpcNode(n))

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group_test.go
@@ -439,7 +439,7 @@ func TestCloudProvider_DeleteNodes(t *testing.T) {
 		client: client,
 	}
 
-	err := ng1.DeleteNodes(nodes)
+	err := ng1.DeleteNodes(nodes, false)
 	assert.NoError(t, err)
 
 	// test grpc error
@@ -457,7 +457,7 @@ func TestCloudProvider_DeleteNodes(t *testing.T) {
 		client: client,
 	}
 
-	err = ng2.DeleteNodes(nodes)
+	err = ng2.DeleteNodes(nodes, false)
 	assert.Error(t, err)
 
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -278,7 +278,7 @@ func (mig *gceMig) Belongs(node *apiv1.Node) (bool, error) {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (mig *gceMig) DeleteNodes(nodes []*apiv1.Node) error {
+func (mig *gceMig) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	size, err := mig.gceManager.GetMigSize(mig)
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -382,13 +382,13 @@ func TestMig(t *testing.T) {
 	gceManagerMock.On("GetMigForInstance", n1ref).Return(mig1, nil).Once()
 	gceManagerMock.On("GetMigForInstance", n2ref).Return(mig1, nil).Once()
 	gceManagerMock.On("DeleteInstances", []GceRef{n1ref, n2ref}).Return(nil).Once()
-	err = mig1.DeleteNodes([]*apiv1.Node{n1, n2})
+	err = mig1.DeleteNodes([]*apiv1.Node{n1, n2}, false)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test DeleteNodes - fail on reaching min size.
 	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(0), nil).Once()
-	err = mig1.DeleteNodes([]*apiv1.Node{n1, n2})
+	err = mig1.DeleteNodes([]*apiv1.Node{n1, n2}, false)
 	assert.Error(t, err)
 	assert.Equal(t, "min size reached, nodes will not be deleted", err.Error())
 	mock.AssertExpectationsForObjects(t, gceManagerMock)

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -134,7 +134,7 @@ func (n *hetznerNodeGroup) IncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *hetznerNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *hetznerNodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	n.clusterUpdateMutex.Lock()
 	defer n.clusterUpdateMutex.Unlock()
 

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
@@ -97,7 +97,7 @@ func (asg *AutoScalingGroup) IncreaseSize(delta int) error {
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (asg *AutoScalingGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (asg *AutoScalingGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	instances, err := asg.cloudServiceManager.GetInstances(asg.groupID)
 	if err != nil {
 		klog.Warningf("failed to get instances from group: %s, error: %v", asg.groupID, err)

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
@@ -85,7 +85,7 @@ func (n *nodePool) IncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *nodePool) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *nodePool) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	if acquired := n.manager.TryLockNodeGroup(n); !acquired {
 		return fmt.Errorf("node deletion already in progress")
 	}

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider_test.go
@@ -133,21 +133,21 @@ func (s *NodeGroupTestSuite) TestIncreaseSize_OK() {
 
 func (s *NodeGroupTestSuite) TestDeleteNodes_Locked() {
 	s.manager.On("TryLockNodeGroup", s.nodePool).Return(false).Once()
-	s.Error(s.nodePool.DeleteNodes(s.deleteNode))
+	s.Error(s.nodePool.DeleteNodes(s.deleteNode, false))
 }
 
 func (s *NodeGroupTestSuite) TestDeleteNodes_DeleteError() {
 	s.manager.On("TryLockNodeGroup", s.nodePool).Return(true).Once()
 	s.manager.On("UnlockNodeGroup", s.nodePool).Return().Once()
 	s.manager.On("DeleteNode", s.nodePool, "testnode").Return(fmt.Errorf("error")).Once()
-	s.Error(s.nodePool.DeleteNodes(s.deleteNode))
+	s.Error(s.nodePool.DeleteNodes(s.deleteNode, false))
 }
 
 func (s *NodeGroupTestSuite) TestDeleteNodes_OK() {
 	s.manager.On("TryLockNodeGroup", s.nodePool).Return(true).Once()
 	s.manager.On("UnlockNodeGroup", s.nodePool).Return().Once()
 	s.manager.On("DeleteNode", s.nodePool, "testnode").Return(nil).Once()
-	s.NoError(s.nodePool.DeleteNodes(s.deleteNode))
+	s.NoError(s.nodePool.DeleteNodes(s.deleteNode, false))
 }
 
 func (s *NodeGroupTestSuite) TestDecreaseTargetSize_InvalidDelta() {

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group.go
@@ -19,6 +19,9 @@ package kamatera
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,8 +30,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
-	"strconv"
-	"strings"
 )
 
 // NodeGroup implements cloudprovider.NodeGroup interface. NodeGroup contains
@@ -87,7 +88,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	for _, node := range nodes {
 		instance, err := n.findInstanceForNode(node)
 		if err != nil {

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group_test.go
@@ -147,7 +147,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 		{Spec: apiv1.NodeSpec{ProviderID: serverName1}},
 		{Spec: apiv1.NodeSpec{ProviderID: serverName2}},
 		{Spec: apiv1.NodeSpec{ProviderID: serverName6}},
-	})
+	}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(ng.instances))
 	assert.Equal(t, serverName3, ng.instances[serverName3].Id)
@@ -155,7 +155,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 	assert.Equal(t, serverName5, ng.instances[serverName5].Id)
 
 	// test error on deleting a node we are not managing
-	err = ng.DeleteNodes([]*apiv1.Node{{Spec: apiv1.NodeSpec{ProviderID: mockKamateraServerName()}}})
+	err = ng.DeleteNodes([]*apiv1.Node{{Spec: apiv1.NodeSpec{ProviderID: mockKamateraServerName()}}}, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot find this node in the node group")
 
@@ -165,7 +165,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 	).Return(fmt.Errorf("error on API call")).Once()
 	err = ng.DeleteNodes([]*apiv1.Node{
 		{Spec: apiv1.NodeSpec{ProviderID: serverName4}},
-	})
+	}, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "error on API call")
 }

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -222,7 +222,7 @@ func (nodeGroup *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // DeleteNodes deletes the specified nodes from the node group.
-func (nodeGroup *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (nodeGroup *NodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	size, err := nodeGroup.kubemarkController.GetNodeGroupTargetSize(nodeGroup.Name)
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/linode/linode_node_group.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_node_group.go
@@ -102,7 +102,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	for _, node := range nodes {
 		pool, err := n.findLKEPoolForNode(node)
 		if err != nil {

--- a/cluster-autoscaler/cloudprovider/linode/linode_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_node_group_test.go
@@ -139,7 +139,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 	}
 
 	// test of on deleting nodes
-	err := ng.DeleteNodes(nodes)
+	err := ng.DeleteNodes(nodes, false)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(ng.lkePools))
 	assert.NotNil(t, ng.lkePools[3])
@@ -149,21 +149,21 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 	nodes = []*apiv1.Node{
 		{Spec: apiv1.NodeSpec{ProviderID: "linode://aaa"}},
 	}
-	err = ng.DeleteNodes(nodes)
+	err = ng.DeleteNodes(nodes, false)
 	assert.Error(t, err)
 
 	// test error on deleting a node we are not managing
 	nodes = []*apiv1.Node{
 		{Spec: apiv1.NodeSpec{ProviderID: "linode://555"}},
 	}
-	err = ng.DeleteNodes(nodes)
+	err = ng.DeleteNodes(nodes, false)
 	assert.Error(t, err)
 
 	// test error on deleting a node when the linode API call fails
 	nodes = []*apiv1.Node{
 		{Spec: apiv1.NodeSpec{ProviderID: "linode://423"}},
 	}
-	err = ng.DeleteNodes(nodes)
+	err = ng.DeleteNodes(nodes, false)
 	assert.Error(t, err)
 }
 

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
@@ -89,7 +89,7 @@ func (ng *magnumNodeGroup) IncreaseSize(delta int) error {
 }
 
 // deleteNodes deletes a set of nodes chosen by the autoscaler.
-func (ng *magnumNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *magnumNodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	ng.clusterUpdateLock.Lock()
 	defer ng.clusterUpdateLock.Unlock()
 

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup_test.go
@@ -240,7 +240,7 @@ func TestDeleteNodes(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		ng.targetSize = 10
 		manager.On("deleteNodes", testNodeGroupUUID, nodeRefs, 5).Return(nil).Once()
-		err := ng.DeleteNodes(nodesToDelete)
+		err := ng.DeleteNodes(nodesToDelete, false)
 		assert.NoError(t, err)
 		assert.Equal(t, 5, ng.targetSize)
 	})
@@ -249,7 +249,7 @@ func TestDeleteNodes(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		ng.targetSize = 10
 		manager.On("deleteNodes", testNodeGroupUUID, nodeRefs, 5).Return(errors.New("manager error")).Once()
-		err := ng.DeleteNodes(nodesToDelete)
+		err := ng.DeleteNodes(nodesToDelete, false)
 		assert.Error(t, err)
 		assert.Equal(t, "manager error deleting nodes: manager error", err.Error())
 	})
@@ -293,7 +293,7 @@ func TestNodes(t *testing.T) {
 	}
 
 	manager.On("deleteNodes", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	err := ng.DeleteNodes(nodesToDelete)
+	err := ng.DeleteNodes(nodesToDelete, false)
 	require.NoError(t, err)
 
 	allNodes := append(runningNodes, deletingNodes...)

--- a/cluster-autoscaler/cloudprovider/mocks/NodeGroup.go
+++ b/cluster-autoscaler/cloudprovider/mocks/NodeGroup.go
@@ -112,7 +112,7 @@ func (_m *NodeGroup) Delete() error {
 }
 
 // DeleteNodes provides a mock function with given fields: _a0
-func (_m *NodeGroup) DeleteNodes(_a0 []*v1.Node) error {
+func (_m *NodeGroup) DeleteNodes(_a0 []*v1.Node, removingFailedNodes bool) error {
 	ret := _m.Called(_a0)
 
 	var r0 error

--- a/cluster-autoscaler/cloudprovider/oci/oci_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/oci_instance_pool.go
@@ -18,6 +18,7 @@ package oci
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -93,7 +94,7 @@ func (ip *InstancePoolNodeGroup) IncreaseSize(delta int) error {
 // DeleteNodes deletes nodes from this instance-pool. Error is returned either on
 // failure or if the given node doesn't belong to this instance-pool. This function
 // should wait until instance-pool size is updated. Implementation required.
-func (ip *InstancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ip *InstancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 
 	// FYI, unregistered nodes come in as the provider id as node name.
 

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
@@ -110,7 +110,7 @@ func (ng *NodeGroup) IncreaseSize(delta int) error {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	// Do not use node group which does not support autoscaling
 	if !ng.Autoscale {
 		return nil

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
@@ -268,7 +268,7 @@ func TestOVHCloudNodeGroup_DeleteNodes(t *testing.T) {
 					ProviderID: "openstack:///instance-1",
 				},
 			},
-		})
+		}, false)
 		assert.NoError(t, err)
 
 		targetSize, err := ng.TargetSize()
@@ -280,7 +280,7 @@ func TestOVHCloudNodeGroup_DeleteNodes(t *testing.T) {
 	t.Run("check delete nodes empty nodes array", func(t *testing.T) {
 		ng.mockCallUpdateNodePool(2, []string{})
 
-		err := ng.DeleteNodes(nil)
+		err := ng.DeleteNodes(nil, false)
 		assert.NoError(t, err)
 
 		targetSize, err := ng.TargetSize()
@@ -315,7 +315,7 @@ func TestOVHCloudNodeGroup_DeleteNodes(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, false)
 		assert.Error(t, err)
 	})
 }

--- a/cluster-autoscaler/cloudprovider/packet/packet_node_group.go
+++ b/cluster-autoscaler/cloudprovider/packet/packet_node_group.go
@@ -104,7 +104,7 @@ func (ng *packetNodeGroup) IncreaseSize(delta int) error {
 //   - simultaneous but separate calls from the autoscaler are batched together
 //   - does not allow scaling while the cluster is already in an UPDATE_IN_PROGRESS state
 //   - after scaling down, blocks until the cluster has reached UPDATE_COMPLETE
-func (ng *packetNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *packetNodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	klog.V(1).Infof("Locking nodesToDeleteMutex")
 
 	// Batch simultaneous deletes on individual nodes

--- a/cluster-autoscaler/cloudprovider/packet/packet_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/packet/packet_node_group_test.go
@@ -144,10 +144,10 @@ func TestIncreaseDecreaseSize(t *testing.T) {
 		}
 	}
 
-	err = ngPool2.DeleteNodes(nodesPool2)
+	err = ngPool2.DeleteNodes(nodesPool2, false)
 	assert.NoError(t, err)
 
-	err = ngPool3.DeleteNodes(nodesPool3)
+	err = ngPool3.DeleteNodes(nodesPool3, false)
 	assert.NoError(t, err)
 
 	// Wait a few seconds if talking to the actual Packet API

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
@@ -106,7 +106,7 @@ func (ng *nodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // DeleteNodes deletes the specified nodes from the node group.
-func (ng *nodeGroup) DeleteNodes(toDelete []*corev1.Node) error {
+func (ng *nodeGroup) DeleteNodes(toDelete []*corev1.Node, removingFailedNodes bool) error {
 	if ng.replicas-len(toDelete) < ng.MinSize() {
 		return fmt.Errorf("node group size would be below minimum size - desired: %d, min: %d",
 			ng.replicas-len(toDelete), ng.MinSize())

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup_test.go
@@ -221,7 +221,7 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 			// store delta before deleting nodes
 			delta := tc.nodeGroup.replicas - tc.expectedTargetSize
 
-			if err := tc.nodeGroup.DeleteNodes(tc.toDelete); err != nil {
+			if err := tc.nodeGroup.DeleteNodes(tc.toDelete, false); err != nil {
 				if tc.expectedErrContains == "" || !strings.Contains(err.Error(), tc.expectedErrContains) {
 					t.Fatalf("expected err to contain %q, got %q", tc.expectedErrContains, err)
 				}

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +31,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
-	"strings"
 )
 
 // NodeGroup implements cloudprovider.NodeGroup interface.
@@ -104,7 +105,7 @@ func (ng *NodeGroup) IncreaseSize(delta int) error {
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated.
-func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	ctx := context.Background()
 	klog.V(4).Info("DeleteNodes,", len(nodes), " nodes to reclaim")
 	for _, n := range nodes {

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group_test.go
@@ -19,11 +19,12 @@ package scaleway
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/scaleway/scalewaygo"
-	"testing"
 )
 
 func TestNodeGroup_TargetSize(t *testing.T) {
@@ -185,7 +186,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 	client.On("DeleteNode", ctx, &scalewaygo.DeleteNodeRequest{NodeID: ng.nodes["scaleway://instance/fr-srr-1/6c22c989-ddce-41d8-98cb-2aea83c72066"].ID}).Return(&scalewaygo.Node{Status: scalewaygo.NodeStatusDeleting}, nil).Once()
 	client.On("DeleteNode", ctx, &scalewaygo.DeleteNodeRequest{NodeID: ng.nodes["scaleway://instance/fr-srr-1/fcc3abe0-3a72-4178-8182-2a93fdc72529"].ID}).Return(&scalewaygo.Node{Status: scalewaygo.NodeStatusDeleting}, nil).Once()
 
-	err := ng.DeleteNodes(nodes)
+	err := ng.DeleteNodes(nodes, false)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(0), ng.p.Size)
 }
@@ -204,7 +205,7 @@ func TestNodeGroup_DeleteNodesErr(t *testing.T) {
 	}
 	client.On("DeleteNode", ctx, &scalewaygo.DeleteNodeRequest{NodeID: "unknown"}).Return(&scalewaygo.Node{}, errors.New("nonexistent")).Once()
 
-	err := ng.DeleteNodes(nodes)
+	err := ng.DeleteNodes(nodes, false)
 	assert.Error(t, err)
 }
 

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_auto_scaling_group.go
@@ -195,7 +195,7 @@ func (asg *tcAsg) Autoprovisioned() bool {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (asg *tcAsg) DeleteNodes(nodes []*apiv1.Node) error {
+func (asg *tcAsg) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	size, err := asg.tencentcloudManager.GetAsgSize(asg)
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -438,7 +438,7 @@ func (tng *TestNodeGroup) DecreaseTargetSize(delta int) error {
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated.
-func (tng *TestNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (tng *TestNodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	tng.Lock()
 	id := tng.id
 	tng.targetSize -= len(nodes)

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_node_group.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_node_group.go
@@ -100,7 +100,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node, removingFailedNodes bool) error {
 	for _, node := range nodes {
 		nodeID, ok := node.Labels[nodeIDLabel]
 

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_node_group_test.go
@@ -203,7 +203,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 
 		client.On("DeleteNodePoolInstance", ctx, ng.clusterID, ng.id, "a").Return(nil).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(nodes, false)
 		assert.NoError(t, err)
 	})
 
@@ -218,7 +218,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 
 		client.On("DeleteNodePoolInstance", ctx, ng.clusterID, ng.id, "a").Return(errors.New("error")).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(nodes, false)
 		assert.Error(t, err)
 	})
 }

--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
@@ -153,7 +153,7 @@ func deleteNodesFromCloudProvider(ctx *context.AutoscalingContext, nodes []*apiv
 	if nodeGroup == nil || reflect.ValueOf(nodeGroup).IsNil() {
 		return nodeGroup, errors.NewAutoscalerError(errors.InternalError, "picked node that doesn't belong to a node group: %s", nodes[0].Name)
 	}
-	if err = nodeGroup.DeleteNodes(nodes); err != nil {
+	if err = nodeGroup.DeleteNodes(nodes, false); err != nil {
 		return nodeGroup, errors.NewAutoscalerError(errors.CloudProviderError, "failed to delete %s: %v", nodes[0].Name, err)
 	}
 	return nodeGroup, nil

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -748,7 +748,7 @@ func removeOldUnregisteredNodes(unregisteredNodes []clusterstate.UnregisteredNod
 				klog.Warningf("Failed to remove node %s: node group min size reached, skipping unregistered node removal", unregisteredNode.Node.Name)
 				continue
 			}
-			err = nodeGroup.DeleteNodes([]*apiv1.Node{unregisteredNode.Node})
+			err = nodeGroup.DeleteNodes([]*apiv1.Node{unregisteredNode.Node}, true)
 			csr.InvalidateNodeInstancesCacheEntry(nodeGroup)
 			if err != nil {
 				klog.Warningf("Failed to remove node %s: %v", unregisteredNode.Node.Name, err)
@@ -800,7 +800,7 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() (bool, error) {
 		if nodeGroup == nil {
 			err = fmt.Errorf("node group %s not found", nodeGroupId)
 		} else {
-			err = nodeGroup.DeleteNodes(nodesToBeDeleted)
+			err = nodeGroup.DeleteNodes(nodesToBeDeleted, true)
 		}
 
 		if err != nil {

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -35,14 +35,14 @@ type FakeNodeGroup struct {
 	id string
 }
 
-func (f *FakeNodeGroup) MaxSize() int                       { return 2 }
-func (f *FakeNodeGroup) MinSize() int                       { return 1 }
-func (f *FakeNodeGroup) TargetSize() (int, error)           { return 2, nil }
-func (f *FakeNodeGroup) IncreaseSize(delta int) error       { return nil }
-func (f *FakeNodeGroup) DecreaseTargetSize(delta int) error { return nil }
-func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error    { return nil }
-func (f *FakeNodeGroup) Id() string                         { return f.id }
-func (f *FakeNodeGroup) Debug() string                      { return f.id }
+func (f *FakeNodeGroup) MaxSize() int                          { return 2 }
+func (f *FakeNodeGroup) MinSize() int                          { return 1 }
+func (f *FakeNodeGroup) TargetSize() (int, error)              { return 2, nil }
+func (f *FakeNodeGroup) IncreaseSize(delta int) error          { return nil }
+func (f *FakeNodeGroup) DecreaseTargetSize(delta int) error    { return nil }
+func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node, bool) error { return nil }
+func (f *FakeNodeGroup) Id() string                            { return f.id }
+func (f *FakeNodeGroup) Debug() string                         { return f.id }
 func (f *FakeNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	return []cloudprovider.Instance{}, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
